### PR TITLE
Clearing

### DIFF
--- a/inc/dynamic_deque.h
+++ b/inc/dynamic_deque.h
@@ -17,6 +17,7 @@ extern size_t dynamic_deque_length(DynamicDeque *dq);
 extern size_t dynamic_deque_data_size(DynamicDeque *dq);
 extern void *dynamic_deque_peek_front(DynamicDeque *dq);
 extern void *dynamic_deque_peek_back(DynamicDeque *dq);
+extern void dynamic_deque_clear(DynamicDeque *dq);
 extern void dynamic_deque_destroy(DynamicDeque *dq);
 
 #endif // DYNAMIC_DEQUE_H

--- a/inc/dynamic_queue.h
+++ b/inc/dynamic_queue.h
@@ -14,6 +14,7 @@ extern size_t dynamic_queue_capacity(DynamicQueue *q);
 extern size_t dynamic_queue_length(DynamicQueue *q);
 extern size_t dynamic_queue_data_size(DynamicQueue *q);
 extern void *dynamic_queue_peek(DynamicQueue *q);
+extern void dynamic_queue_clear(DynamicQueue *q);
 extern void dynamic_queue_destroy(DynamicQueue *q);
 
 #endif // DYNAMIC_QUEUE_H

--- a/inc/dynamic_stack.h
+++ b/inc/dynamic_stack.h
@@ -14,6 +14,7 @@ extern size_t dynamic_stack_capacity(DynamicStack *q);
 extern size_t dynamic_stack_length(DynamicStack *q);
 extern size_t dynamic_stack_data_size(DynamicStack *q);
 extern void *dynamic_stack_peek(DynamicStack *q);
+extern void dynamic_stack_clear(DynamicStack *q);
 extern void dynamic_stack_destroy(DynamicStack *q);
 
 #endif // DYNAMIC_QUEUE_H

--- a/src/dynamic_deque.c
+++ b/src/dynamic_deque.c
@@ -35,9 +35,9 @@ int __reallocate_data_buffer(DynamicDeque *dq) {
                internals->__head * internals->__data_size);
         internals->__tail = internals->__head + internals->__len - 1;
     }
-    if (internals->__head > internals->__capacity / 2) {
-        memmove(internals->__data_buf + ((internals->__capacity / 4) * internals->__data_size), internals->__data_buf + (internals->__head * internals->__data_size), internals->__data_size * internals->__len);
-        internals->__head = internals->__capacity / 4;
+    if (internals->__head > (internals->__capacity >> 1)) {
+        memmove(internals->__data_buf + ((internals->__capacity >> 2) * internals->__data_size), internals->__data_buf + (internals->__head * internals->__data_size), internals->__data_size * internals->__len);
+        internals->__head = internals->__capacity >> 2;
         internals->__tail = internals->__head + internals->__len - 1;
     }
     return 0;

--- a/src/dynamic_deque.c
+++ b/src/dynamic_deque.c
@@ -149,6 +149,12 @@ void *dynamic_deque_peek_back(DynamicDeque *dq) {
     return internals->__data_buf + (internals->__tail * internals->__data_size);
 }
 
+void dynamic_deque_clear(DynamicDeque *dq) {
+    ddq_internals *internals = dq->internals;
+    memset(internals->__data_buf, '\0', internals->__data_size * internals->__capacity);
+    internals->__head = internals->__tail = internals->__len = 0;
+}
+
 void dynamic_deque_destroy(DynamicDeque *dq) {
     ddq_internals *internals = dq->internals;
     free(internals->__data_buf);

--- a/src/dynamic_queue.c
+++ b/src/dynamic_queue.c
@@ -22,4 +22,6 @@ size_t dynamic_queue_data_size(DynamicQueue *q) { return dynamic_deque_data_size
 
 void *dynamic_queue_peek(DynamicQueue *q) { return dynamic_deque_peek_front((DynamicDeque *)q); }
 
+void dynamic_queue_clear(DynamicQueue *q) { dynamic_deque_clear((DynamicDeque *)q); }
+
 void dynamic_queue_destroy(DynamicQueue *q) { dynamic_deque_destroy((DynamicDeque *)q); }

--- a/src/dynamic_stack.c
+++ b/src/dynamic_stack.c
@@ -22,4 +22,6 @@ size_t dynamic_stack_data_size(DynamicStack *q) { return dynamic_deque_data_size
 
 void *dynamic_stack_peek(DynamicStack *q) { return dynamic_deque_peek_back((DynamicDeque *)q); }
 
+void dynamic_stack_clear(DynamicStack *q) { dynamic_deque_clear((DynamicDeque *)q); }
+
 void dynamic_stack_destroy(DynamicStack *q) { dynamic_deque_destroy((DynamicDeque *)q); }


### PR DESCRIPTION
Add clear() functionality to deque, stack, and queue interfaces. Also shift deques during resizes since there is already a cost associated with memmoves.